### PR TITLE
fix port checking on Win32 by performing it in another process

### DIFF
--- a/lib/Test/TCP/CheckPort.pm
+++ b/lib/Test/TCP/CheckPort.pm
@@ -1,0 +1,28 @@
+package Test::TCP::CheckPort;
+use strict;
+use warnings;
+use base qw/Exporter/;
+use IO::Socket::INET;
+
+our @EXPORT = qw/ check_port shell_check_port /;
+
+sub shell_check_port { print check_port( @ARGV ) }
+
+sub check_port {
+    my ( $port ) = @_;
+
+    my $remote = IO::Socket::INET->new(
+        Proto    => 'tcp',
+        PeerAddr => '127.0.0.1',
+        PeerPort => $port,
+    );
+    if ( $remote ) {
+        close $remote;
+        return 1;
+    }
+    else {
+        return 0;
+    }
+}
+
+1;


### PR DESCRIPTION
On Win32 fork is emulating by creating another thread in the same process.
This leads to a possible bug/race condition when a server tries to open a
port and listen on it, while in the same process a client tries to connect
to the same port. This manifests by the accept call of the server failing
with an error of "Bad file descriptor".

This is easily fixed by having another process perform the port checking,
since that will not interfere with the internals.

The necessary change is implemented in this commit and only necessary for
win32. It does however work everywhere else with no downside so special
casing is not necessary or useful.
