### PR TITLE
fix port checking on Win32 by performing it in another process

### DIFF
--- a/lib/Test/TCP.pm
+++ b/lib/Test/TCP.pm
@@ -79,7 +79,7 @@ sub wait_port {
 
     my $retry = 100;
     while ( $retry-- ) {
-        return if _check_port($port);
+        return if $^O eq 'MSWin32' ? `$^X -MTest::TCP::CheckPort -echeck_port $port` : _check_port( $port );
         Time::HiRes::sleep(0.1);
     }
     die "cannot open port: $port";

--- a/lib/Test/TCP/CheckPort.pm
+++ b/lib/Test/TCP/CheckPort.pm
@@ -1,0 +1,11 @@
+package Test::TCP::CheckPort;
+use strict;
+use warnings;
+use base qw/Exporter/;
+use Test::TCP ();
+
+our @EXPORT = qw/ check_port /;
+
+sub check_port { print Test::TCP::_check_port( @ARGV ) }
+
+1;


### PR DESCRIPTION
On Win32 fork is emulating by creating another thread in the same process.
This leads to a possible bug/race condition when a server tries to open a
port and listen on it, while in the same process a client tries to connect
to the same port. This manifests by the accept call of the server failing
with an error of "Bad file descriptor".

This is easily fixed by having another process perform the port checking,
since that will not interfere with the internals.
