### PR TITLE
Change wait_port() API to take max_wait seconds, and wait exponentially 

### DIFF
--- a/t/11_net_empty_port.t
+++ b/t/11_net_empty_port.t
@@ -5,7 +5,7 @@ use Net::EmptyPort;
 
 my $port = empty_port;
 ok $port, "found an empty port";
-ok !wait_port( $port, 0.1, 1 ), "port is closed";
+ok !wait_port( $port, 0.1 ), "port is closed";
 
 my $sock = IO::Socket::INET->new(
     LocalAddr => '127.0.0.1',
@@ -13,6 +13,6 @@ my $sock = IO::Socket::INET->new(
     Listen    => 1,
 ) or die "Couldn't create socket: $!";
 
-ok wait_port( $port, 2.1, 1 ), "port is open";
+ok wait_port( $port, 3 ), "port is open";
 
 done_testing;

--- a/t/12_pass_wait_port_options.t
+++ b/t/12_pass_wait_port_options.t
@@ -4,31 +4,28 @@ use utf8;
 use Test::More;
 use Test::TCP;
 
-my ($port, $sleep, $retry);
+my ($port, $max_wait);
 {
     no warnings 'redefine';
     *Net::EmptyPort::wait_port = sub {
-        ($port, $sleep, $retry) = @_;
+        ($port, $max_wait) = @_;
         1;
     };
 }
 
 # Test::TCP::wait_port arguments are passed to Net::EmptyPort::wait_port.
 {
-    Test::TCP::wait_port(1, 0.00001, 3);
-    is($sleep, 0.00001);
-    is($retry, 3);
+    Test::TCP::wait_port(1, 1);
+    is($max_wait, 1);
 }
 
 # Test::TCP#new arguments are passed to Net::EmptyPort::wait_port.
 {
     my $tcp = Test::TCP->new(
         code => sub { },
-        wait_port_retry => 4,
-        wait_port_sleep => 0.00008,
+        max_wait => 3,
     );
-    is($sleep, 0.00008);
-    is($retry, 4);
+    is($max_wait, 3);
 }
 
 # test_tcp() arguments are passed to Net::EmptyPort::wait_port.
@@ -38,11 +35,9 @@ my ($port, $sleep, $retry);
         },
         server => sub {
         },
-        wait_port_retry => 2,
-        wait_port_sleep => 0.00009,
+        max_wait => 2,
     );
-    is($sleep, 0.00009);
-    is($retry, 2);
+    is($max_wait, 2);
 }
 
 done_testing;


### PR DESCRIPTION
Instead of specifying sleep interval and retry, let users specify the maximum wait time, then use exponential sleep counter, starting from 0.001 - which takes the best of both fast initial check, as well as tolerant wait intervals for a slow server.

cc @kazeburo 
