### PR TITLE
Support IPv6, make it usable on an IPv6-only host

### DIFF
--- a/lib/Test/TCP.pm
+++ b/lib/Test/TCP.pm
@@ -161,7 +161,7 @@ Test::TCP - testing TCP program
             ...
         },
     );
-    my $client = MyClient->new(host => '127.0.0.1', port => $server->port);
+    my $client = MyClient->new(host => 'localhost', port => $server->port);
     undef $server; # kill child process on DESTROY
 
 Using memcached:
@@ -176,7 +176,7 @@ Using memcached:
             die "cannot execute $bin: $!";
         },
     );
-    my $memd = Cache::Memcached->new({servers => ['127.0.0.1:' . $memcached->port]});
+    my $memd = Cache::Memcached->new({servers => ['localhost:' . $memcached->port]});
     ...
 
 And functional interface is available:
@@ -346,7 +346,7 @@ You can use C<exec()> in child process.
     );
 
     use Cache::Memcached;
-    my $memd = Cache::Memcached->new({servers => ['127.0.0.1:' . $memcached->port]});
+    my $memd = Cache::Memcached->new({servers => ['localhost:' . $memcached->port]});
     $memd->set(foo => 'bar');
     is $memd->get('foo'), 'bar';
 

--- a/t/01_simple.t
+++ b/t/01_simple.t
@@ -2,16 +2,26 @@ use warnings;
 use strict;
 use Test::More tests => 22;
 use Test::TCP;
-use IO::Socket::INET;
 use t::Server;
+
+our $io_socket_module_name;
+BEGIN {
+  if (eval { require IO::Socket::IP }) {
+    $io_socket_module_name = 'IO::Socket::IP';
+  } elsif (eval { require IO::Socket::INET6 }) {
+    $io_socket_module_name = 'IO::Socket::INET6';
+  } elsif (eval { require IO::Socket::INET }) {
+    $io_socket_module_name = 'IO::Socket::INET';
+  }
+}
 
 test_tcp(
     client => sub {
         my $port = shift;
         ok $port, "test case for sharedfork" for 1..10;
-        my $sock = IO::Socket::INET->new(
+        my $sock = $io_socket_module_name->new(
             PeerPort => $port,
-            PeerAddr => '127.0.0.1',
+            PeerAddr => 'localhost',
             Proto    => 'tcp'
         ) or die "Cannot open client socket: $!";
 

--- a/t/02_abrt.t
+++ b/t/02_abrt.t
@@ -3,8 +3,18 @@ use warnings;
 use Test::TCP;
 use Test::More;
 use Socket;
-use IO::Socket::INET;
 use t::Server;
+
+our $io_socket_module_name;
+BEGIN {
+  if (eval { require IO::Socket::IP }) {
+    $io_socket_module_name = 'IO::Socket::IP';
+  } elsif (eval { require IO::Socket::INET6 }) {
+    $io_socket_module_name = 'IO::Socket::INET6';
+  } elsif (eval { require IO::Socket::INET }) {
+    $io_socket_module_name = 'IO::Socket::INET';
+  }
+}
 
 plan skip_all => "win32 doesn't support embedded function named dump()" if $^O eq 'MSWin32';
 plan tests => 2;
@@ -12,9 +22,9 @@ plan tests => 2;
 test_tcp(
     client => sub {
         my $port = shift;
-        my $sock = IO::Socket::INET->new(
+        my $sock = $io_socket_module_name->new(
             PeerPort => $port,
-            PeerAddr => '127.0.0.1',
+            PeerAddr => 'localhost',
             Proto    => 'tcp'
         ) or die "Cannot open client socket: $!";
         print {$sock} "dump\n";

--- a/t/04_die.t
+++ b/t/04_die.t
@@ -2,7 +2,6 @@ use warnings;
 use strict;
 use Test::More tests => 3;
 use Test::TCP;
-use IO::Socket::INET;
 use t::Server;
 
 my $child_pid;

--- a/t/05_sigint.t
+++ b/t/05_sigint.t
@@ -1,10 +1,20 @@
 use strict;
 use warnings;
 use Test::TCP;
-use IO::Socket::INET;
 use POSIX;
 use Test::More;
 use Config;
+
+our $io_socket_module_name;
+BEGIN {
+  if (eval { require IO::Socket::IP }) {
+    $io_socket_module_name = 'IO::Socket::IP';
+  } elsif (eval { require IO::Socket::INET6 }) {
+    $io_socket_module_name = 'IO::Socket::INET6';
+  } elsif (eval { require IO::Socket::INET }) {
+    $io_socket_module_name = 'IO::Socket::INET';
+  }
+}
 
 plan skip_all => "this test requires SIGUSR1" unless $Config{sig_name} =~ /USR1/;
 plan skip_all => "Perl<5.8.8 does not supports \${^CHILD_ERROR_NATIVE}" if $] <= 5.008008;
@@ -31,8 +41,8 @@ if ($pid > 0) {
         },
         server => sub {
             my $port = shift;
-            my $sock = IO::Socket::INET->new(
-                LocalAddr => '127.0.0.1',
+            my $sock = $io_socket_module_name->new(
+                LocalAddr => 'localhost',
                 LocalPort => $port,
                 Listen    => 5,
                 ReuseAddr => 1,

--- a/t/09_fork.t
+++ b/t/09_fork.t
@@ -3,6 +3,17 @@ use Test::More tests => 6;
 use Test::TCP;
 use t::Server;
 
+our $io_socket_module_name;
+BEGIN {
+  if (eval { require IO::Socket::IP }) {
+    $io_socket_module_name = 'IO::Socket::IP';
+  } elsif (eval { require IO::Socket::INET6 }) {
+    $io_socket_module_name = 'IO::Socket::INET6';
+  } elsif (eval { require IO::Socket::INET }) {
+    $io_socket_module_name = 'IO::Socket::INET';
+  }
+}
+
 test_tcp 
     client => sub {
         my $port = shift;
@@ -27,9 +38,9 @@ test_tcp
 
         # after the child has exited, we need to make sure that
         # the server hasn't gone away.
-        my $sock = IO::Socket::INET->new(
+        my $sock = $io_socket_module_name->new(
             PeerPort => $port,
-            PeerAddr => '127.0.0.1',
+            PeerAddr => 'localhost',
             Proto    => 'tcp'
         );
         if (! ok $sock, "socket is connected") {

--- a/t/10_oo.t
+++ b/t/10_oo.t
@@ -2,8 +2,18 @@ use warnings;
 use strict;
 use Test::More tests => 22;
 use Test::TCP;
-use IO::Socket::INET;
 use t::Server;
+
+our $io_socket_module_name;
+BEGIN {
+  if (eval { require IO::Socket::IP }) {
+    $io_socket_module_name = 'IO::Socket::IP';
+  } elsif (eval { require IO::Socket::INET6 }) {
+    $io_socket_module_name = 'IO::Socket::INET6';
+  } elsif (eval { require IO::Socket::INET }) {
+    $io_socket_module_name = 'IO::Socket::INET';
+  }
+}
 
 my $server = Test::TCP->new(
     code => sub {
@@ -18,9 +28,9 @@ my $server = Test::TCP->new(
 );
 
 ok $server->port, "test case for sharedfork" for 1..10;
-my $sock = IO::Socket::INET->new(
+my $sock = $io_socket_module_name->new(
     PeerPort => $server->port,
-    PeerAddr => '127.0.0.1',
+    PeerAddr => 'localhost',
     Proto    => 'tcp'
 ) or die "Cannot open client socket: $!";
 

--- a/t/11_net_empty_port.t
+++ b/t/11_net_empty_port.t
@@ -3,12 +3,23 @@ use warnings;
 use Test::More;
 use Net::EmptyPort;
 
+our $io_socket_module_name;
+BEGIN {
+  if (eval { require IO::Socket::IP }) {
+    $io_socket_module_name = 'IO::Socket::IP';
+  } elsif (eval { require IO::Socket::INET6 }) {
+    $io_socket_module_name = 'IO::Socket::INET6';
+  } elsif (eval { require IO::Socket::INET }) {
+    $io_socket_module_name = 'IO::Socket::INET';
+  }
+}
+
 my $port = empty_port;
 ok $port, "found an empty port";
 ok !wait_port( $port, 0.1 ), "port is closed";
 
-my $sock = IO::Socket::INET->new(
-    LocalAddr => '127.0.0.1',
+my $sock = $io_socket_module_name->new(
+    LocalAddr => 'localhost',
     LocalPort => $port,
     Listen    => 1,
 ) or die "Couldn't create socket: $!";

--- a/t/13_undef_port.t
+++ b/t/13_undef_port.t
@@ -2,16 +2,26 @@ use warnings;
 use strict;
 use Test::More tests => 22;
 use Test::TCP;
-use IO::Socket::INET;
 use t::Server;
+
+our $io_socket_module_name;
+BEGIN {
+  if (eval { require IO::Socket::IP }) {
+    $io_socket_module_name = 'IO::Socket::IP';
+  } elsif (eval { require IO::Socket::INET6 }) {
+    $io_socket_module_name = 'IO::Socket::INET6';
+  } elsif (eval { require IO::Socket::INET }) {
+    $io_socket_module_name = 'IO::Socket::INET';
+  }
+}
 
 test_tcp(
     client => sub {
         my $port = shift;
         ok $port, "test case for sharedfork" for 1..10;
-        my $sock = IO::Socket::INET->new(
+        my $sock = $io_socket_module_name->new(
             PeerPort => $port,
-            PeerAddr => '127.0.0.1',
+            PeerAddr => 'localhost',
             Proto    => 'tcp'
         ) or die "Cannot open client socket: $!";
 

--- a/t/Server.pm
+++ b/t/Server.pm
@@ -2,15 +2,26 @@ package t::Server;
 use strict;
 use warnings;
 use base qw/Exporter/;
-use IO::Socket::INET;
+use IO::Socket;
 
 our @EXPORT = qw/new_sock/;
 
+our $io_socket_module_name;
+BEGIN {
+  if (eval { require IO::Socket::IP }) {
+    $io_socket_module_name = 'IO::Socket::IP';
+  } elsif (eval { require IO::Socket::INET6 }) {
+    $io_socket_module_name = 'IO::Socket::INET6';
+  } elsif (eval { require IO::Socket::INET }) {
+    $io_socket_module_name = 'IO::Socket::INET';
+  }
+}
+
 sub new_sock {
     my $port = shift;
-    my $sock = IO::Socket::INET->new(
+    my $sock = $io_socket_module_name->new(
         LocalPort => $port,
-        LocalAddr => '127.0.0.1',
+        LocalAddr => 'localhost',
         Proto     => 'tcp',
         Listen    => 5,
         Type      => SOCK_STREAM,

--- a/xt/author/11_net_emptyport.t
+++ b/xt/author/11_net_emptyport.t
@@ -2,7 +2,17 @@ use warnings;
 use strict;
 use Test::More tests => 11;
 use Net::EmptyPort qw(empty_port check_port);
-use IO::Socket::INET;
+
+our $io_socket_module_name;
+BEGIN {
+  if (eval { require IO::Socket::IP }) {
+    $io_socket_module_name = 'IO::Socket::IP';
+  } elsif (eval { require IO::Socket::INET6 }) {
+    $io_socket_module_name = 'IO::Socket::INET6';
+  } elsif (eval { require IO::Socket::INET }) {
+    $io_socket_module_name = 'IO::Socket::INET';
+  }
+}
 
 # This UDP test case does not portable if there is DNS cache server.
 
@@ -15,9 +25,9 @@ foreach my $proto_uc ('TCP', 'UDP') {
 
     diag "Port: $port - $proto";
 
-    $sock = new_ok( 'IO::Socket::INET' => [
+    $sock = new_ok( $io_socket_module_name => [
         (($proto eq 'udp') ? () : (Listen => 5)),
-        LocalAddr => '127.0.0.1',
+        LocalAddr => 'localhost',
         LocalPort => $port,
         Proto     => $proto,
         (($^O eq 'MSWin32') ? () : (ReuseAddr => 1)),
@@ -28,12 +38,12 @@ foreach my $proto_uc ('TCP', 'UDP') {
     diag "New port: $new_port - $proto";
 
     $sock->close;
-    $sock = new_ok( 'IO::Socket::INET' => [
+    $sock = new_ok( $io_socket_module_name => [
         (($proto eq 'udp') ? () : (Listen => 5)),
-        LocalAddr => '127.0.0.1',
+        LocalAddr => 'localhost',
         LocalPort => $port,
-        PeerAddr  => '127.0.0.1',
-        PeerPort  => $new_port,
+      # PeerAddr  => 'localhost',
+      # PeerPort  => $new_port,
         Proto     => $proto,
         (($^O eq 'MSWin32') ? () : (ReuseAddr => 1)),
     ] );


### PR DESCRIPTION
The Test-TCP is currently unusable on an IPv6-only host or
inside a jail (like on a FreeBSD) which does not have a loopback
interface and no IP address 127.0.0.1.  Consequently, any other
Perl module which uses Test-TCP in its tests will fail its
self-tests on such host.

The proposed change lets Test-TCP adapt to its network environment.

Instead of unconditionally using a module IO::Socket::INET
which does not support IPv6 protocol family, try to use the
modern IO::Socket::IP, falling back to older IO::Socket::INET6,
or ultimately to IO::Socket::INET if that is the only module
available. Instead of assuming the loopback interface has
an IP address 127.0.0.1 (which it may not have, e.g. on an
IPv6-only host its only IP address is ::1), use a host name
'localhost', which is recognized by all three IO::Socket::*
modules and resolve to whatever IP address is available.

Btw, the 'localhost' change in the POD section example regarding
Cache::Memcached was tested and works, the Cache::Memcached::new
will happily accept "localhost:11211" as servers specification.

Feel free to factor-out or otherwise modify the common new code
section in t/*.t .