### PR TITLE
Fix unitialized warning

### DIFF
--- a/lib/Net/EmptyPort.pm
+++ b/lib/Net/EmptyPort.pm
@@ -95,6 +95,7 @@ sub wait_port {
         $proto = $proto ? lc($proto) : 'tcp';
     }
 
+    $max_wait = 10 unless defined $max_wait;
     my $waiter = _make_waiter($max_wait);
 
     while ( $waiter->() ) {
@@ -174,7 +175,8 @@ This method waits the C<< $port >> number is ready to accept a request.
 
 C<$port> is a port number to check.
 
-Sleep up to C<$max_wait> seconds for checking the port.
+Sleep up to C<$max_wait> seconds (10 seconds by default) for checking the
+port.
 
 I<Return value> : Return true if the port is available, false otherwise.
 


### PR DESCRIPTION
This fixes two small problems with Net::EmptyPort. First, `wait_port` documentation says that `max_wait` argument is optional, but if it is omitted it gives a warning:

```
$ perl -MNet::EmptyPort -E'wait_port 1111'
Use of uninitialized value $max_wait in numeric gt (>) at /home/.../perl5/perlbrew/perls/perl-5.18.1/lib/site_perl/5.18.1/Net/EmptyPort.pm line 76.
Use of uninitialized value $max_wait in numeric gt (>) at /home/.../perl5/perlbrew/perls/perl-5.18.1/lib/site_perl/5.18.1/Net/EmptyPort.pm line 76.
```

Second, in compatibility mode it tries to compute `max_wait` as `$max_wait*$retry` which is wrong, as `$max_wait` is not defined yet, it should be `$sleep * $retry`.
