### PR TITLE
Skip tests requiring fork() when no fork() is available

### DIFF
--- a/t/01_simple.t
+++ b/t/01_simple.t
@@ -1,9 +1,18 @@
 use warnings;
 use strict;
-use Test::More tests => 22;
+use Config;
+use Test::More;
 use Test::TCP;
 use IO::Socket::INET;
 use t::Server;
+
+plan skip_all => "fork not supported on this platform"
+  unless $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+    (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+     $Config::Config{useithreads} and
+     $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/);
+
+plan tests => 22;
 
 test_tcp(
     client => sub {

--- a/t/03_return_when_sigterm.t
+++ b/t/03_return_when_sigterm.t
@@ -1,8 +1,17 @@
 use warnings;
 use strict;
-use Test::More tests => 2;
+use Config;
+use Test::More;
 use Test::TCP;
 use t::Server;
+
+plan skip_all => "fork not supported on this platform"
+  unless $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+    (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+     $Config::Config{useithreads} and
+     $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/);
+
+plan tests => 2;
 
 # ABOUT: some tcp server related software returns control when received SIGTERM instead of exit.
 # This test emulate it's situation.

--- a/t/04_die.t
+++ b/t/04_die.t
@@ -1,9 +1,18 @@
 use warnings;
 use strict;
-use Test::More tests => 3;
+use Config;
+use Test::More;
 use Test::TCP;
 use IO::Socket::INET;
 use t::Server;
+
+plan skip_all => "fork not supported on this platform"
+  unless $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+    (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+     $Config::Config{useithreads} and
+     $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/);
+
+plan tests => 3;
 
 my $child_pid;
 eval {

--- a/t/06_nest.t
+++ b/t/06_nest.t
@@ -1,8 +1,17 @@
 use strict;
 use warnings;
+use Config;
 use Test::TCP;
-use Test::More tests => 1;
+use Test::More;
 use t::Server;
+
+plan skip_all => "fork not supported on this platform"
+  unless $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+    (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+     $Config::Config{useithreads} and
+     $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/);
+
+plan tests => 1;
 
 test_tcp(
     client => sub {

--- a/t/08_exit.t
+++ b/t/08_exit.t
@@ -1,11 +1,20 @@
 use strict;
 use warnings;
-use Test::More tests => 5;
+use Config;
+use Test::More;
 use Test::TCP;
 use File::Temp ();
 use Fcntl qw/:seek/;
 use t::Server;
 use POSIX;
+
+plan skip_all => "fork not supported on this platform"
+  unless $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+    (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+     $Config::Config{useithreads} and
+     $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/);
+
+plan tests => 5;
 
 my $tmp = File::Temp->new();
 

--- a/t/09_fork.t
+++ b/t/09_fork.t
@@ -1,7 +1,16 @@
 use strict;
-use Test::More tests => 6;
+use Config;
+use Test::More;
 use Test::TCP;
 use t::Server;
+
+plan skip_all => "fork not supported on this platform"
+  unless $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+    (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+     $Config::Config{useithreads} and
+     $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/);
+
+plan tests => 6;
 
 test_tcp 
     client => sub {

--- a/t/10_oo.t
+++ b/t/10_oo.t
@@ -1,9 +1,18 @@
 use warnings;
 use strict;
-use Test::More tests => 22;
+use Config;
+use Test::More;
 use Test::TCP;
 use IO::Socket::INET;
 use t::Server;
+
+plan skip_all => "fork not supported on this platform"
+  unless $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+    (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+     $Config::Config{useithreads} and
+     $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/);
+
+plan tests => 22;
 
 my $server = Test::TCP->new(
     code => sub {

--- a/t/12_pass_wait_port_options.t
+++ b/t/12_pass_wait_port_options.t
@@ -1,10 +1,17 @@
 use strict;
 use warnings;
 use utf8;
+use Config;
 use Test::More;
 use Test::TCP;
 use IO::Socket::INET;
 use t::Server;
+
+plan skip_all => "fork not supported on this platform"
+  unless $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+    (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+     $Config::Config{useithreads} and
+     $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/);
 
 my ($port, $max_wait);
 my $old = \&Net::EmptyPort::wait_port;

--- a/t/13_undef_port.t
+++ b/t/13_undef_port.t
@@ -1,9 +1,18 @@
 use warnings;
 use strict;
-use Test::More tests => 22;
+use Config;
+use Test::More;
 use Test::TCP;
 use IO::Socket::INET;
 use t::Server;
+
+plan skip_all => "fork not supported on this platform"
+  unless $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+    (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+     $Config::Config{useithreads} and
+     $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/);
+
+plan tests => 22;
 
 test_tcp(
     client => sub {


### PR DESCRIPTION
If you build perl on Windows without -DPERL_IMPLICIT_SYS (which I do, in
order to enable -DPEL_MALLOC, which seems faster than using the system
malloc()) then you don't get the fork() emulation and several of
Test-TCP's tests fail.

This commit skips those tests in the same manner as various other CPAN
modules do in this case. This allows a normal "cpan install ..." of
Test-TCP or anything depending on it (e.g. Plack) to succeed without
having to "force" anything.
