### PR TITLE
IPv6 support

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -7,6 +7,7 @@ requires 'Time::HiRes';
 on test => sub {
     requires 'Test::More', '0.98';
     requires 'File::Temp';
+    requires 'IO::Socket::IP';
     requires 'Socket';
 };
 

--- a/lib/Net/EmptyPort.pm
+++ b/lib/Net/EmptyPort.pm
@@ -99,7 +99,7 @@ sub wait_port {
         ($port, $max_wait, $proto) = @_;
     }
     $host = '127.0.0.1' unless defined $host;
-    $max_wait = 10 unless defined $max_wait;
+    $max_wait ||= 10;
     $proto = $proto ? lc($proto) : 'tcp';
     my $waiter = _make_waiter($max_wait);
 

--- a/lib/Net/EmptyPort.pm
+++ b/lib/Net/EmptyPort.pm
@@ -2,7 +2,7 @@ package Net::EmptyPort;
 use strict;
 use warnings;
 use base qw/Exporter/;
-use IO::Socket::INET;
+use IO::Socket::IP;
 use Time::HiRes ();
 
 our @EXPORT = qw/ empty_port check_port wait_port /;
@@ -10,26 +10,26 @@ our @EXPORT = qw/ empty_port check_port wait_port /;
 # get a empty port on 49152 .. 65535
 # http://www.iana.org/assignments/port-numbers
 sub empty_port {
-    my $port = do {
-        if (defined $_[0]) {
-            my $p = $_[0];
-            $p = 49152 unless $p =~ /^[0-9]+$/ && $p < 49152;
-            $p;
-        } else {
-            50000 + (int(rand()*1500) + abs($$)) % 1500;
-        }
-    };
-    my $proto = $_[1] ? lc($_[1]) : 'tcp';
+    my ($host, $port, $proto) = @_ && ref $_[0] eq 'HASH' ? ($_[0]->{host}, $_[0]->{port}, $_[0]->{proto}) : (undef, @_);
+    $host = '127.0.0.1'
+        unless defined $host;
+    if (defined $port) {
+        $port = 49152 unless $port =~ /^[0-9]+$/ && $port < 49152;
+    } else {
+        $port = 50000 + (int(rand()*1500) + abs($$)) % 1500;
+    }
+    $proto = $proto ? lc($proto) : 'tcp';
 
     while ( $port++ < 65000 ) {
         # Remote checks don't work on UDP, and Local checks would be redundant here...
-        next if ($proto eq 'tcp' && check_port($port));
+        next if ($proto eq 'tcp' && check_port({ host => $host, port => $port }));
 
-        my $sock = IO::Socket::INET->new(
+        my $sock = IO::Socket::IP->new(
             (($proto eq 'udp') ? () : (Listen => 5)),
-            LocalAddr => '127.0.0.1',
+            LocalAddr => $host,
             LocalPort => $port,
             Proto     => $proto,
+            V6Only    => 1,
             (($^O eq 'MSWin32') ? () : (ReuseAddr => 1)),
         );
         return $port if $sock;
@@ -38,21 +38,25 @@ sub empty_port {
 }
 
 sub check_port {
-    my $port = $_[0];
-    my $proto = $_[1] ? lc($_[1]) : 'tcp';
+    my ($host, $port, $proto) = @_ && ref $_[0] eq 'HASH' ? ($_[0]->{host}, $_[0]->{port}, $_[0]->{proto}) : (undef, @_);
+    $host = '127.0.0.1'
+        unless defined $host;
+    $proto = $proto ? lc($proto) : 'tcp';
 
     # for TCP, we do a remote port check
     # for UDP, we do a local port check, like empty_port does
     my $sock = ($proto eq 'tcp') ?
-        IO::Socket::INET->new(
+        IO::Socket::IP->new(
             Proto    => 'tcp',
-            PeerAddr => '127.0.0.1',
+            PeerAddr => $host,
             PeerPort => $port,
+            V6Only   => 1,
         ) :
-        IO::Socket::INET->new(
+        IO::Socket::IP->new(
             Proto     => $proto,
-            LocalAddr => '127.0.0.1',
+            LocalAddr => $host,
             LocalPort => $port,
+            V6Only   => 1,
             (($^O eq 'MSWin32') ? () : (ReuseAddr => 1)),
         )
     ;
@@ -84,22 +88,23 @@ sub _make_waiter {
 }
 
 sub wait_port {
-    my ($port, $max_wait, $proto);
-    if (@_==4) {
+    my ($host, $port, $max_wait, $proto);
+    if (@_ && ref $_[0] eq 'HASH') {
+        ($host, $port, $max_wait, $proto) = ($_[0]->{host}, $_[0]->{port}, $_[0]->{max_wait}, $_[0]->{proto});
+    } elsif (@_==4) {
         # backward compat.
         ($port, (my $sleep), (my $retry), $proto) = @_;
         $max_wait = $sleep * $retry;
-        $proto = $proto ? lc($proto) : 'tcp';
     } else {
         ($port, $max_wait, $proto) = @_;
-        $proto = $proto ? lc($proto) : 'tcp';
     }
-
+    $host = '127.0.0.1' unless defined $host;
     $max_wait = 10 unless defined $max_wait;
+    $proto = $proto ? lc($proto) : 'tcp';
     my $waiter = _make_waiter($max_wait);
 
     while ( $waiter->() ) {
-        if ($^O eq 'MSWin32' ? `$^X -MTest::TCP::CheckPort -echeck_port $port $proto` : check_port( $port, $proto )) {
+        if ($^O eq 'MSWin32' ? `$^X -MTest::TCP::CheckPort -echeck_port $port $proto` : check_port({ host => $host, port => $port, proto => $proto })) {
             return 1;
         }
     }

--- a/lib/Test/TCP.pm
+++ b/lib/Test/TCP.pm
@@ -24,13 +24,10 @@ sub test_tcp {
         die "missing madatory parameter $k" unless exists $args{$k};
     }
     my $server_code = delete $args{server};
-    my $port = delete($args{port}) || empty_port();
-
     my $client_code = delete $args{client};
 
     my $server = Test::TCP->new(
         code => $server_code,
-        port => $port,
         %args,
     );
     $client_code->($server->port, $server->pid);
@@ -65,7 +62,7 @@ sub new {
         _my_pid    => $$,
         %args,
     }, $class;
-    $self->{port} = empty_port() unless exists $self->{port};
+    $self->{port} ||= empty_port();
     $self->start()
       if $self->{auto_start};
     return $self;

--- a/lib/Test/TCP.pm
+++ b/lib/Test/TCP.pm
@@ -35,18 +35,24 @@ sub test_tcp {
 }
 
 sub wait_port {
-    my ($port, $max_wait);
-    if (@_==3) {
+    my ($host, $port, $max_wait);
+    if (@_ && ref $_[0] eq 'HASH') {
+        $host = $_[0]->{host};
+        $port = $_[0]->{port};
+        $max_wait = $_[0]->{max_wait};
+    } elsif (@_ == 3) {
         # backward compat
         ($port, (my $sleep), (my $retry)) = @_;
         $max_wait = $sleep * $retry;
-    }  else {
+    } else {
         ($port, $max_wait) = @_;
     }
+    $host = '127.0.0.1'
+        unless defined $host;
     $max_wait ||= 10;
 
-    Net::EmptyPort::wait_port($port, $max_wait)
-        or die "cannot open port: $port";
+    Net::EmptyPort::wait_port({ host => $host, port => $port, max_wait => $max_wait })
+        or die "cannot open port: $host:$port";
 }
 
 # ------------------------------------------------------------------------- 
@@ -59,10 +65,11 @@ sub new {
     my $self = bless {
         auto_start => 1,
         max_wait   => 10,
+        host       => '127.0.0.1',
         _my_pid    => $$,
         %args,
     }, $class;
-    $self->{port} ||= empty_port();
+    $self->{port} ||= empty_port({ host => $self->{host} });
     $self->start()
       if $self->{auto_start};
     return $self;
@@ -78,7 +85,7 @@ sub start {
 
     if ( $pid ) { # parent process.
         $self->{pid} = $pid;
-        Test::TCP::wait_port($self->port, $self->{max_wait});
+        Test::TCP::wait_port({ host => $self->{host}, port => $self->port, max_wait => $self->{max_wait} });
         return;
     } else { # child process
         $self->{code}->($self->port);

--- a/t/01_simple.t
+++ b/t/01_simple.t
@@ -1,41 +1,62 @@
 use warnings;
 use strict;
-use Test::More tests => 22;
+use Test::More;
 use Test::TCP;
-use IO::Socket::INET;
+use IO::Socket::IP;
 use t::Server;
 
-test_tcp(
-    client => sub {
-        my $port = shift;
-        ok $port, "test case for sharedfork" for 1..10;
-        my $sock = IO::Socket::INET->new(
-            PeerPort => $port,
-            PeerAddr => '127.0.0.1',
-            Proto    => 'tcp'
-        ) or die "Cannot open client socket: $!";
+sub doit {
+    my $host = shift;
+    test_tcp(
+        client => sub {
+            my $port = shift;
+            ok $port, "test case for sharedfork" for 1..10;
+            my $sock = IO::Socket::IP->new(
+                PeerPort => $port,
+                PeerAddr => $host,
+                Proto    => 'tcp',
+                V6Only   => 1,
+            ) or die "Cannot open client socket: $!";
 
-        note "send 1";
-        print {$sock} "foo\n";
-        my $res = <$sock>;
-        is $res, "foo\n";
+            note "send 1";
+            print {$sock} "foo\n";
+            my $res = <$sock>;
+            is $res, "foo\n";
 
-        note "send 2";
-        print {$sock} "bar\n";
-        my $res2 = <$sock>;
-        is $res2, "bar\n";
+            note "send 2";
+            print {$sock} "bar\n";
+            my $res2 = <$sock>;
+            is $res2, "bar\n";
 
-        note "finalize";
-        print {$sock} "quit\n";
-    },
-    server => sub {
-        my $port = shift;
-        ok $port, "test case for sharedfork" for 1..10;
-        t::Server->new($port)->run(sub {
-            note "new request";
-            my ($remote, $line, $sock) = @_;
-            print {$remote} $line;
-        });
-    },
-);
+            note "finalize";
+            print {$sock} "quit\n";
+        },
+        server => sub {
+            my $port = shift;
+            ok $port, "test case for sharedfork" for 1..10;
+            t::Server->new($host, $port)->run(sub {
+                note "new request";
+                my ($remote, $line, $sock) = @_;
+                print {$remote} $line;
+            });
+        },
+        host => $host,
+    );
+}
 
+subtest 'v4' => sub {
+    doit('127.0.0.1');
+};
+subtest 'v6' => sub {
+    do {
+        local $@;
+        my $p = eval {
+            empty_port({ host => '::1' });
+        };
+        plan skip_all => "IPv6 not supported"
+            if $@;
+    };
+    doit('::1');
+};
+
+done_testing;

--- a/t/02_abrt.t
+++ b/t/02_abrt.t
@@ -25,7 +25,7 @@ test_tcp(
     },
     server => sub {
         my $port = shift;
-        t::Server->new($port)->run(sub {
+        t::Server->new('127.0.0.1', $port)->run(sub {
             my ($remote, $line) = @_;
             print {$remote} $line;
             if ($line =~ /dump/) {

--- a/t/03_return_when_sigterm.t
+++ b/t/03_return_when_sigterm.t
@@ -14,7 +14,7 @@ test_tcp(
     },
     server => sub {
         my $port = shift;
-        my $sock = new_sock($port);
+        my $sock = new_sock('127.0.0.1', $port);
         my $term_received = 0;
         $SIG{TERM} = sub { $term_received++ };
         while ($term_received == 0) {

--- a/t/04_die.t
+++ b/t/04_die.t
@@ -16,7 +16,7 @@ eval {
         },
         server => sub {
             my $port = shift;
-            t::Server->new($port)->run(sub { });
+            t::Server->new('127.0.0.1', $port)->run(sub { });
         },
     );
 };

--- a/t/06_nest.t
+++ b/t/06_nest.t
@@ -14,13 +14,13 @@ test_tcp(
             },
             server => sub {
                 my $port2 = shift;
-                t::Server->new($port2)->run;
+                t::Server->new('127.0.0.1', $port2)->run;
             },
         );
     },
     server => sub {
         my $port1 = shift;
-        t::Server->new($port1)->run;
+        t::Server->new('127.0.0.1', $port1)->run;
     },
 );
 

--- a/t/08_exit.t
+++ b/t/08_exit.t
@@ -44,7 +44,7 @@ if ($pid) { # parent
             note "SEVER: $$";
             print {$tmp} $$;
             $tmp->close;
-            t::Server->new($port)->run(sub {
+            t::Server->new('127.0.0.1', $port)->run(sub {
                 note "new request";
                 my ($remote, $line, $sock) = @_;
                 print {$remote} $line;

--- a/t/09_fork.t
+++ b/t/09_fork.t
@@ -42,7 +42,7 @@ test_tcp
     },
     server => sub {
         my $port = shift;
-        t::Server->new($port)->run(sub {
+        t::Server->new('127.0.0.1', $port)->run(sub {
             note "new request";
             my ($remote, $line, $sock) = @_;
             print {$remote} $line;

--- a/t/10_oo.t
+++ b/t/10_oo.t
@@ -9,7 +9,7 @@ my $server = Test::TCP->new(
     code => sub {
         my $port = shift;
         ok $port, "test case for sharedfork" for 1..10;
-        t::Server->new($port)->run(sub {
+        t::Server->new('127.0.0.1', $port)->run(sub {
             note "new request";
             my ($remote, $line, $sock) = @_;
             print {$remote} $line;

--- a/t/11_net_empty_port.t
+++ b/t/11_net_empty_port.t
@@ -28,7 +28,7 @@ subtest 'v6' => sub {
     my $port = do {
         local $@;
         my $p = eval {
-            empty_port();
+            empty_port({ host => '::1' });
         };
         plan skip_all => "IPv6 not supported"
             if $@;

--- a/t/11_net_empty_port.t
+++ b/t/11_net_empty_port.t
@@ -1,18 +1,41 @@
 use strict;
 use warnings;
+use IO::Socket::IP;
 use Test::More;
 use Net::EmptyPort;
 
-my $port = empty_port;
-ok $port, "found an empty port";
-ok !wait_port( $port, 0.1 ), "port is closed";
+sub doit {
+    my ($host, $port) = @_;
+    ok !wait_port({ host => $host, port => $port, max_wait => 0.1 }), "port is closed";
 
-my $sock = IO::Socket::INET->new(
-    LocalAddr => '127.0.0.1',
-    LocalPort => $port,
-    Listen    => 1,
-) or die "Couldn't create socket: $!";
+    my $sock = IO::Socket::IP->new(
+        LocalAddr => $host,
+        LocalPort => $port,
+        Listen    => 1,
+        V6Only    => 1,
+    ) or die "Couldn't create socket: $!";
 
-ok wait_port( $port, 3 ), "port is open";
+    ok wait_port({ host => $host, port => $port, max_wait => 3 }), "port is open";
+};
+
+subtest 'v4' => sub {
+    my $port = empty_port();
+    ok "found an empty port";
+    doit('127.0.0.1', $port);
+};
+
+subtest 'v6' => sub {
+    my $port = do {
+        local $@;
+        my $p = eval {
+            empty_port();
+        };
+        plan skip_all => "IPv6 not supported"
+            if $@;
+        $p;
+    };
+    ok "found an empty port";
+    doit('::1', $port);
+};
 
 done_testing;

--- a/t/12_pass_wait_port_options.t
+++ b/t/12_pass_wait_port_options.t
@@ -6,14 +6,14 @@ use Test::TCP;
 use IO::Socket::INET;
 use t::Server;
 
-my ($port, $max_wait);
+my %wait_port_args;
 my $old = \&Net::EmptyPort::wait_port;
 my $return = sub { 1 };
 
 {
     no warnings 'redefine';
     *Net::EmptyPort::wait_port = sub {
-        ($port, $max_wait) = @_;
+        %wait_port_args = %{$_[0]};
         $return->(@_);
     };
 }
@@ -21,7 +21,7 @@ my $return = sub { 1 };
 # Test::TCP::wait_port arguments are passed to Net::EmptyPort::wait_port.
 {
     Test::TCP::wait_port(1, 1);
-    is($max_wait, 1);
+    is($wait_port_args{max_wait}, 1);
 }
 
 $return = sub { $old->(@_) };
@@ -73,7 +73,7 @@ my $client = sub {
         $? = 0;
     }
 
-    is($max_wait, -3);
+    is($wait_port_args{max_wait}, -3);
 }
 
 # test_tcp() arguments are passed to Net::EmptyPort::wait_port.
@@ -83,7 +83,7 @@ my $client = sub {
         server => $server,
         max_wait => -2,
     );
-    is($max_wait, -2);
+    is($wait_port_args{max_wait}, -2);
 }
 
 done_testing;

--- a/t/12_pass_wait_port_options.t
+++ b/t/12_pass_wait_port_options.t
@@ -29,7 +29,7 @@ $return = sub { $old->(@_) };
 my $server = sub {
     my $port = shift;
     ok $port, "test case for sharedfork" for 1 .. 10;
-    t::Server->new($port)->run(sub {
+    t::Server->new('127.0.0.1', $port)->run(sub {
             note "new request";
             my ($remote, $line, $sock) = @_;
             print {$remote} $line;

--- a/t/13_undef_port.t
+++ b/t/13_undef_port.t
@@ -31,7 +31,7 @@ test_tcp(
     server => sub {
         my $port = shift;
         ok $port, "test case for sharedfork" for 1..10;
-        t::Server->new($port)->run(sub {
+        t::Server->new('127.0.0.1', $port)->run(sub {
             note "new request";
             my ($remote, $line, $sock) = @_;
             print {$remote} $line;

--- a/t/Server.pm
+++ b/t/Server.pm
@@ -2,27 +2,28 @@ package t::Server;
 use strict;
 use warnings;
 use base qw/Exporter/;
-use IO::Socket::INET;
+use IO::Socket::IP;
 
 our @EXPORT = qw/new_sock/;
 
 sub new_sock {
-    my $port = shift;
-    my $sock = IO::Socket::INET->new(
+    my ($host, $port) = @_;
+    my $sock = IO::Socket::IP->new(
         LocalPort => $port,
-        LocalAddr => '127.0.0.1',
+        LocalAddr => $host,
         Proto     => 'tcp',
         Listen    => 5,
         Type      => SOCK_STREAM,
+        V6Only    => 1,
         (($^O eq 'MSWin32') ? () : (ReuseAddr => 1)),
     ) or die "Cannot open server socket: $!";
     return $sock;
 }
 
 sub new {
-    my ($class, $port) = @_;
+    my ($class, $host, $port) = @_;
 
-    my $sock = new_sock($port);
+    my $sock = new_sock($host, $port);
     bless { sock => $sock }, $class;
 }
 


### PR DESCRIPTION
This PR adds IPv6 support to Test::TCP.

The commits basically makes following changes to the public functions to add support for IPv6 while maintaining backwards compatibility:

* accept hash-style arguments
* recognize `host` parameter in the hash-style arguments, and bind to the specified address
* the default value of the `host` parameter is `127.0.0.1`

If the design and implementation seems fine, I would update the documents.