### PR TITLE
IO::Socket::IP is required not only on test time

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,6 @@
 requires 'perl', 5.008_001;
 requires 'IO::Socket::INET';
+requires 'IO::Socket::IP';
 requires 'Test::SharedFork', '0.29';
 requires 'Test::More';
 requires 'Time::HiRes';
@@ -7,7 +8,6 @@ requires 'Time::HiRes';
 on test => sub {
     requires 'Test::More', '0.98';
     requires 'File::Temp';
-    requires 'IO::Socket::IP';
     requires 'Socket';
 };
 


### PR DESCRIPTION
EmptyPort.pm uses IO::Socket::IP so it is not a test-only dependency.

Unless one have IO::Socket::IP installed already this means that dist simply fails to compile despite installing all declared dependencies.