### PR TITLE
Test coverage

### DIFF
--- a/lib/Test/TCP.pm
+++ b/lib/Test/TCP.pm
@@ -21,7 +21,7 @@ my $TERMSIG = $^O eq 'MSWin32' ? 'KILL' : 'TERM';
 sub test_tcp {
     my %args = @_;
     for my $k (qw/client server/) {
-        die "missing madatory parameter $k" unless exists $args{$k};
+        die "missing mandatory parameter $k" unless exists $args{$k};
     }
     my $server_code = delete $args{server};
     my $client_code = delete $args{client};

--- a/t/04_die.t
+++ b/t/04_die.t
@@ -1,6 +1,6 @@
 use warnings;
 use strict;
-use Test::More tests => 3;
+use Test::More tests => 9;
 use Test::TCP;
 use IO::Socket::INET;
 use t::Server;
@@ -33,3 +33,17 @@ if ($?) {
     $? = 0;
 }
 
+eval { test_tcp (); };
+$e = $@;
+ok ($e, 'No client is fatal error');
+like ($e, qr/missing mandatory parameter client/, 'No client is fatal error');
+
+eval { test_tcp (client => 1); };
+$e = $@;
+ok ($e, 'No server is fatal error');
+like ($e, qr/missing mandatory parameter server/, 'No server is fatal error');
+
+eval { Test::TCP->new (); };
+$e = $@;
+ok ($e, 'No code is fatal error');
+like ($e, qr/missing mandatory parameter 'code'/, 'No code is fatal error');

--- a/t/10_oo.t
+++ b/t/10_oo.t
@@ -1,6 +1,6 @@
 use warnings;
 use strict;
-use Test::More tests => 22;
+use Test::More tests => 24;
 use Test::TCP;
 use IO::Socket::INET;
 use t::Server;
@@ -43,6 +43,22 @@ if ($?) {
     diag "test_tcp() leaks \$?. Maybe it's Perl bug?: $?";
     $? = 0;
 }
+
+my $s2 = Test::TCP->new (
+	code	=>	sub { return 1; },
+	port	=>	8080,
+	auto_start => 0
+);
+is ($s2->port, 8080, 'Specify port');
+
+$s2 = Test::TCP->new (
+	{
+		code	=>	sub { return 1; },
+		port	=>	8080,
+		auto_start => 0
+	}
+);
+is ($s2->port, 8080, 'Args as hashref');
 
 done_testing;
 

--- a/t/10_oo.t
+++ b/t/10_oo.t
@@ -45,18 +45,18 @@ if ($?) {
 }
 
 my $s2 = Test::TCP->new (
-	code	=>	sub { return 1; },
-	port	=>	8080,
-	auto_start => 0
+    code        => sub { return 1; },
+    port        => 8080,
+    auto_start  => 0
 );
 is ($s2->port, 8080, 'Specify port');
 
 $s2 = Test::TCP->new (
-	{
-		code	=>	sub { return 1; },
-		port	=>	8080,
-		auto_start => 0
-	}
+    {
+        code        => sub { return 1; },
+        port        => 8080,
+        auto_start  => 0
+    }
 );
 is ($s2->port, 8080, 'Args as hashref');
 

--- a/t/10_oo.t
+++ b/t/10_oo.t
@@ -44,6 +44,8 @@ if ($?) {
     $? = 0;
 }
 
+waitpid($server->pid, 0);
+
 my $s2 = Test::TCP->new (
     code        => sub { return 1; },
     port        => 8080,

--- a/t/11_net_empty_port.t
+++ b/t/11_net_empty_port.t
@@ -49,9 +49,9 @@ cmp_ok ($port, '>', 49151, 'Specified non-numeric port and udp proto to empty_po
 
 $port = empty_port ();
 ok (!wait_port ($port, 0.1, 2, 'tcp'),
-	'4 args to wait_port (backwards compat)');
+    '4 args to wait_port (backwards compat)');
 ok (!wait_port ($port, 0.2, 'tcp'),
-	'3 args to wait_port');
+    '3 args to wait_port');
 eval { wait_port (); };
 like ($@, qr/Expected .PeerService./, 'No args to wait_port is fatal');
 ok (!wait_port ($port), 'No max_wait to wait_port');

--- a/t/11_net_empty_port.t
+++ b/t/11_net_empty_port.t
@@ -36,4 +36,28 @@ subtest 'v6' => sub {
     doit('::1');
 };
 
+my $port = empty_port (8080, 'tcp');
+ok ($port, 'Non hashref arg to empty_port');
+cmp_ok ($port, '<', 49152, 'Specified low port to empty_port');
+$port = empty_port (50000, 'tcp');
+cmp_ok ($port, '>', 49151, 'Specified high port to empty_port');
+$port = empty_port ('alpha', 'tcp');
+cmp_ok ($port, '>', 49151, 'Specified non-numeric port to empty_port');
+$port = empty_port ('alpha', 'udp');
+cmp_ok ($port, '>', 49151, 'Specified non-numeric port and udp proto to empty_port');
+
+
+$port = empty_port ();
+ok (!wait_port ($port, 0.1, 2, 'tcp'),
+	'4 args to wait_port (backwards compat)');
+ok (!wait_port ($port, 0.2, 'tcp'),
+	'3 args to wait_port');
+eval { wait_port (); };
+like ($@, qr/Expected .PeerService./, 'No args to wait_port is fatal');
+ok (!wait_port ($port), 'No max_wait to wait_port');
+
+eval { check_port (); };
+like ($@, qr/Expected .PeerService./, 'No args to check_port is fatal');
+ok (!check_port (empty_port(), 'tcp'), '2 args to check_port');
+
 done_testing;

--- a/t/11_net_empty_port.t
+++ b/t/11_net_empty_port.t
@@ -36,6 +36,15 @@ subtest 'v6' => sub {
     doit('::1');
 };
 
+subtest 'return value' => sub {
+    my $sock = IO::Socket::IP->new(
+        LocalAddr => '127.0.0.1',
+        LocalPort => empty_port(),
+        Listen    => 1,
+    );
+    ok $sock;
+};
+
 my $port = empty_port (8080, 'tcp');
 ok ($port, 'Non hashref arg to empty_port');
 cmp_ok ($port, '<', 49152, 'Specified low port to empty_port');

--- a/t/12_pass_wait_port_options.t
+++ b/t/12_pass_wait_port_options.t
@@ -22,6 +22,12 @@ my $return = sub { 1 };
 {
     Test::TCP::wait_port(1, 1);
     is($wait_port_args{max_wait}, 1);
+    Test::TCP::wait_port ();
+    is($wait_port_args{max_wait}, 10, 'Default max_wait');
+    is($wait_port_args{host}, '127.0.0.1', 'Default host');
+    Test::TCP::wait_port (2, 5, 7);
+    is($wait_port_args{port}, 2, 'Backwards compatible port');
+    is($wait_port_args{max_wait}, 35, 'Backwards compatible max_wait');
 }
 
 $return = sub { $old->(@_) };


### PR DESCRIPTION
Here are some additional tests to improve the coverage. Please be aware that I do not have access to any MSWin32 systems so have not been able to test the changes on that platform.

These additional tests have shown up one thing which you might consider a bug: If the user does not supply a port to check_port() or to wait_port() (which the POD describes as being mandatory) the code does not test this but passes the undef along to IO::Socket::IP->new() which then throws the exception "Expected 'PeerService'". A couple of my new tests look for this error but you might consider it to be better if check_port() and wait_port() would check that a port has been supplied and carp something appropriate otherwise.

I hope you find this PR useful. The work has been done as part of the [CPAN PR Challenge](http://cpan-prc.org/).
