### PR TITLE
check whether the OS implements IPV6_V6ONLY before using it

### DIFF
--- a/t/01_simple.t
+++ b/t/01_simple.t
@@ -51,7 +51,7 @@ subtest 'v4' => sub {
 };
 subtest 'v6' => sub {
     plan skip_all => "IPv6 not supported"
-        unless can_bind("::1");
+        unless eval { Socket::IPV6_V6ONLY } and can_bind("::1");
     doit('::1');
 };
 

--- a/t/11_net_empty_port.t
+++ b/t/11_net_empty_port.t
@@ -31,7 +31,7 @@ subtest 'v4' => sub {
 
 subtest 'v6' => sub {
     plan skip_all => "IPv6 not supported"
-        unless can_bind('::1');
+        unless eval { Socket::IPV6_V6ONLY } and can_bind("::1");
     ok "found an empty port";
     doit('::1');
 };


### PR DESCRIPTION
This prevents tests from dying and counting as FAIL on systems that don't support `IPV6_V6ONLY`.