### PR TITLE
Fix race condition in t/10_oo.t

### DIFF
--- a/t/10_oo.t
+++ b/t/10_oo.t
@@ -13,6 +13,7 @@ my $server = Test::TCP->new(
             note "new request";
             my ($remote, $line, $sock) = @_;
             print {$remote} $line;
+            exit 0 if $line eq "quit\n";
         });
     }
 );
@@ -43,6 +44,8 @@ if ($?) {
     diag "test_tcp() leaks \$?. Maybe it's Perl bug?: $?";
     $? = 0;
 }
+
+waitpid($server->pid, 0);
 
 done_testing;
 


### PR DESCRIPTION
Depending on various versions, system performance, etc. this test could
end up hitting 'done_testing' before the final note is produced in the
child process.

In stable Test::More/Test::Sharedfork there is a bug in that the tests
pass despite stuff happening after done_testing. In the new Test::* code
this is detected and considered a fatal error (to prevent false passes).

This patch makes the child exit after the last event, the parent waits
on the childs PID before calling done_testing. This ensures the child
can finish its work before the parent calls done_testing.