### PR TITLE
UNIX domain socket support

### DIFF
--- a/lib/Test/UNIXSock.pm
+++ b/lib/Test/UNIXSock.pm
@@ -1,0 +1,403 @@
+package Test::UNIXSock;
+use strict;
+use warnings;
+use 5.00800;
+our $VERSION = '2.12';
+use base qw/Exporter/;
+use IO::Socket::UNIX;
+use Test::SharedFork 0.12;
+use Test::More ();
+use Config;
+use POSIX;
+use Time::HiRes ();
+use Carp ();
+use File::Temp qw/ tempdir /;
+
+our @EXPORT = qw/ test_unix_sock wait_unix_sock /;
+
+# process does not die when received SIGTERM, on win32.
+my $TERMSIG = $^O eq 'MSWin32' ? 'KILL' : 'TERM';
+
+sub test_unix_sock {
+    my %args = @_;
+    for my $k (qw/client server/) {
+        die "missing madatory parameter $k" unless exists $args{$k};
+    }
+    my $server_code = delete $args{server};
+    my $client_code = delete $args{client};
+
+    my $server = Test::UNIXSock->new(
+        code => $server_code,
+        %args,
+    );
+    $client_code->($server->path, $server->pid);
+    undef $server; # make sure
+}
+
+sub wait_unix_sock {
+    my ($path, $max_wait);
+    if (@_ && ref $_[0] eq 'HASH') {
+        $path = $_[0]->{path};
+        $max_wait = $_[0]->{max_wait};
+    } elsif (@_ == 3) {
+        # backward compat
+        ($path, (my $sleep), (my $retry)) = @_;
+        $max_wait = $sleep * $retry;
+    } else {
+        ($path, $max_wait) = @_;
+    }
+    $max_wait ||= 10;
+    while (--$max_wait > 0) {
+        IO::Socket::UNIX->new(
+            Type => SOCK_STREAM,
+            Peer => $path,
+        ) && return;
+        sleep 1;
+    }
+}
+
+# ------------------------------------------------------------------------- 
+# OO-ish interface
+
+sub new {
+    my $class = shift;
+    my %args = @_==1 ? %{$_[0]} : @_;
+    Carp::croak("missing mandatory parameter 'code'") unless exists $args{code};
+    my $self = bless {
+        auto_start => 1,
+        max_wait   => 10,
+        _my_pid    => $$,
+        tmpdir     => tempdir( CLEANUP => 1 ),
+        %args,
+    }, $class;
+    $self->{path} ||= $self->{tmpdir} . "/test.sock";
+    $self->start()
+      if $self->{auto_start};
+    return $self;
+}
+
+sub pid  { $_[0]->{pid} }
+sub path { $_[0]->{path} }
+
+sub start {
+    my $self = shift;
+    my $pid = fork();
+    die "fork() failed: $!" unless defined $pid;
+
+    if ( $pid ) { # parent process.
+        $self->{pid} = $pid;
+        Test::UNIXSock::wait_unix_sock({ path => $self->path, max_wait => $self->{max_wait} });
+        return;
+    } else { # child process
+        $self->{code}->($self->path);
+        # should not reach here
+        if (kill 0, $self->{_my_pid}) { # warn only parent process still exists
+            warn("[Test::UNIXSocket] Child process does not block(PID: $$, PPID: $self->{_my_pid})");
+        }
+        exit 0;
+    }
+}
+
+sub stop {
+    my $self = shift;
+
+    return unless defined $self->{pid};
+    return unless $self->{_my_pid} == $$;
+
+    kill $TERMSIG => $self->{pid};
+
+    local $?; # waitpid modifies original $?.
+    LOOP: while (1) {
+        my $kid = waitpid( $self->{pid}, 0 );
+        if (POSIX::WIFSIGNALED($?)) {
+            my $signame = (split(' ', $Config{sig_name}))[POSIX::WTERMSIG($?)];
+            if ($signame =~ /^(ABRT|PIPE)$/) {
+                Test::More::diag("your server received SIG$signame");
+            }
+        }
+        if ($kid == 0 || $kid == -1) {
+            last LOOP;
+        }
+    }
+    undef $self->{pid};
+}
+
+sub DESTROY {
+    my $self = shift;
+    local $@;
+    $self->stop();
+}
+
+1;
+__END__
+
+=for stopwords OO-ish
+
+=encoding utf8
+
+=head1 NAME
+
+Test::TCP - testing TCP program
+
+=head1 SYNOPSIS
+
+    use Test::TCP;
+
+    my $server = Test::TCP->new(
+        code => sub {
+            my $port = shift;
+            ...
+        },
+    );
+    my $client = MyClient->new(host => '127.0.0.1', port => $server->port);
+    undef $server; # kill child process on DESTROY
+
+Using memcached:
+
+    use Test::TCP;
+
+    my $memcached = Test::TCP->new(
+        code => sub {
+            my $port = shift;
+
+            exec $bin, '-p' => $port;
+            die "cannot execute $bin: $!";
+        },
+    );
+    my $memd = Cache::Memcached->new({servers => ['127.0.0.1:' . $memcached->port]});
+    ...
+
+And functional interface is available:
+
+    use Test::TCP;
+    test_tcp(
+        client => sub {
+            my ($port, $server_pid) = @_;
+            # send request to the server
+        },
+        server => sub {
+            my $port = shift;
+            # run server
+        },
+    );
+
+=head1 DESCRIPTION
+
+Test::TCP is test utilities for TCP/IP programs.
+
+=head1 METHODS
+
+=over 4
+
+=item test_tcp
+
+Functional interface.
+
+    test_tcp(
+        client => sub {
+            my $port = shift;
+            # send request to the server
+        },
+        server => sub {
+            my $port = shift;
+            # run server
+        },
+        # optional
+        host => '127.0.0.1', # specify '::1' to test using IPv6
+        port => 8080,
+        max_wait => 3, # seconds
+    );
+
+
+=item wait_port
+
+    wait_port(8080);
+
+Waits for a particular port is available for connect.
+
+=back
+
+=head1 OO-ish interface
+
+=over 4
+
+=item my $server = Test::TCP->new(%args);
+
+Create new instance of Test::TCP.
+
+Arguments are following:
+
+=over 4
+
+=item $args{auto_start}: Boolean
+
+Call C<< $server->start() >> after create instance.
+
+Default: true
+
+=item $args{code}: CodeRef
+
+The callback function. Argument for callback function is: C<< $code->($pid) >>.
+
+This parameter is required.
+
+=item $args{max_wait} : Number
+
+Will wait for at most C<$max_wait> seconds before checking port.
+
+See also L<Net::EmptyPort>.
+
+I<Default: 10>
+
+=back
+
+=item $server->start()
+
+Start the server process. Normally, you don't need to call this method.
+
+=item $server->stop()
+
+Stop the server process.
+
+=item my $pid = $server->pid();
+
+Get the pid of child process.
+
+=item my $port = $server->port();
+
+Get the port number of child process.
+
+=back
+
+=head1 FAQ
+
+=over 4
+
+=item How to invoke two servers?
+
+You can call test_tcp() twice!
+
+    test_tcp(
+        client => sub {
+            my $port1 = shift;
+            test_tcp(
+                client => sub {
+                    my $port2 = shift;
+                    # some client code here
+                },
+                server => sub {
+                    my $port2 = shift;
+                    # some server2 code here
+                },
+            );
+        },
+        server => sub {
+            my $port1 = shift;
+            # some server1 code here
+        },
+    );
+
+Or use OO-ish interface instead.
+
+    my $server1 = Test::TCP->new(code => sub {
+        my $port1 = shift;
+        ...
+    });
+    my $server2 = Test::TCP->new(code => sub {
+        my $port2 = shift;
+        ...
+    });
+
+    # your client code here.
+    ...
+
+=item How do you test server program written in other languages like memcached?
+
+You can use C<exec()> in child process.
+
+    use strict;
+    use warnings;
+    use utf8;
+    use Test::More;
+    use Test::TCP 1.08;
+    use File::Which;
+
+    my $bin = scalar which 'memcached';
+    plan skip_all => 'memcached binary is not found' unless defined $bin;
+
+    my $memcached = Test::TCP->new(
+        code => sub {
+            my $port = shift;
+
+            exec $bin, '-p' => $port;
+            die "cannot execute $bin: $!";
+        },
+    );
+
+    use Cache::Memcached;
+    my $memd = Cache::Memcached->new({servers => ['127.0.0.1:' . $memcached->port]});
+    $memd->set(foo => 'bar');
+    is $memd->get('foo'), 'bar';
+
+    done_testing;
+
+=item How do I use address other than "127.0.0.1" for testing?
+
+You can use the C<< host >> parameter to specify the bind address.
+
+    # let the server bind to "0.0.0.0" for testing
+    test_tcp(
+        client => sub {
+            ...
+        },
+        server => sub {
+            ...
+        },
+        host => '0.0.0.0',
+    );
+
+=item How should I write IPv6 tests?
+
+You should use the `Net::EmptyPort::can_bind` function to check if the program can bind to the loopback address of IPv6, as well as the `host` parameter of the `test_tcp` function to specify the same address as the bind address.
+
+    use Net::EmptyPort qw(can_bind);
+
+    plan skip_all => "IPv6 not available"
+        unless can_bind('::1');
+
+    test_tcp(
+        client => sub {
+            ...
+        },
+        server => sub {
+            ...
+        },
+        host => '::1',
+    );
+
+=back
+
+=head1 AUTHOR
+
+Tokuhiro Matsuno E<lt>tokuhirom@gmail.comE<gt>
+
+=head1 THANKS TO
+
+kazuhooku
+
+dragon3
+
+charsbar
+
+Tatsuhiko Miyagawa
+
+lestrrat
+
+=head1 SEE ALSO
+
+=head1 LICENSE
+
+This library is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself.
+
+=cut

--- a/lib/Test/UNIXSock.pm
+++ b/lib/Test/UNIXSock.pm
@@ -68,10 +68,12 @@ sub new {
         auto_start => 1,
         max_wait   => 10,
         _my_pid    => $$,
-        tmpdir     => tempdir( CLEANUP => 1 ),
         %args,
     }, $class;
-    $self->{path} ||= $self->{tmpdir} . "/test.sock";
+    unless (defined $self->{path}) {
+        $self->{tmpdir} = tempdir( CLEANUP => 1 );
+        $self->{path} = $self->{tmpdir} . "/test.sock";
+    }
     $self->start()
       if $self->{auto_start};
     return $self;

--- a/t/14_simple_unix.t
+++ b/t/14_simple_unix.t
@@ -1,5 +1,13 @@
 use warnings;
 use strict;
+
+BEGIN {
+    if ($^O =~ m/^(?:qnx|nto|vos|MSWin32)$/ ) {
+        print "1..0 # Skip: UNIX domain sockets not implemented on $^O\n";
+        exit 0;
+    }
+};
+
 use Test::More;
 use Test::UNIXSock;
 use IO::Socket::UNIX;

--- a/t/14_simple_unix.t
+++ b/t/14_simple_unix.t
@@ -1,0 +1,46 @@
+use warnings;
+use strict;
+use Test::More;
+use Test::UNIXSock;
+use IO::Socket::UNIX;
+use t::ServerUNIX;
+
+sub doit {
+    ok 1, "starting the test";
+    test_unix_sock(
+        client => sub {
+            my $path = shift;
+            ok $path, "test case for sharedfork" for 1..10;
+            my $sock = IO::Socket::UNIX->new(
+                Peer => $path,
+                Type => SOCK_STREAM(),
+            ) or die "Cannot open client socket: $!";
+
+            note "send 1";
+            print {$sock} "foo\n";
+            my $res = <$sock>;
+            is $res, "foo\n";
+
+            note "send 2";
+            print {$sock} "bar\n";
+            my $res2 = <$sock>;
+            is $res2, "bar\n";
+
+            note "finalize";
+            print {$sock} "quit\n";
+        },
+        server => sub {
+            my $path = shift;
+            ok $path, "test case for sharedfork" for 1..10;
+            t::ServerUNIX->new($path)->run(sub {
+                note "new request";
+                my ($remote, $line, $sock) = @_;
+                print {$remote} $line;
+            });
+        },
+    );
+}
+
+doit();
+
+done_testing;

--- a/t/15_oo_unix.t
+++ b/t/15_oo_unix.t
@@ -1,0 +1,47 @@
+use warnings;
+use strict;
+
+BEGIN {
+    if ($^O =~ m/^(?:qnx|nto|vos|MSWin32)$/ ) {
+        print "1..0 # Skip: UNIX domain sockets not implemented on $^O\n";
+        exit 0;
+    }
+};
+
+use Test::More;
+use Test::UNIXSock;
+use IO::Socket::UNIX;
+use t::ServerUNIX;
+
+my $server = Test::UNIXSock->new(
+    code => sub {
+        my $path = shift;
+        ok $path, "test case for sharedfork" for 1..10;
+        t::ServerUNIX->new($path)->run(sub {
+            note "new request";
+            my ($remote, $line, $sock) = @_;
+            print {$remote} $line;
+        });
+    }
+);
+
+ok $server->path, "test case for sharedfork" for 1..10;
+my $sock = IO::Socket::UNIX->new(
+    Peer => $server->path,
+    Type => SOCK_STREAM(),
+) or die "Cannot open client socket: $!";
+
+note "send 1";
+print {$sock} "foo\n";
+my $res = <$sock>;
+is $res, "foo\n";
+
+note "send 2";
+print {$sock} "bar\n";
+my $res2 = <$sock>;
+is $res2, "bar\n";
+
+note "finalize";
+print {$sock} "quit\n";
+
+done_testing;

--- a/t/ServerUNIX.pm
+++ b/t/ServerUNIX.pm
@@ -1,0 +1,18 @@
+package t::ServerUNIX;
+use strict;
+use warnings;
+use IO::Socket::UNIX;
+use base q/t::Server/;
+
+sub new {
+    my ($class, $path) = @_;
+
+    my $sock = IO::Socket::UNIX->new(
+        Local  => $path,
+        Type   => SOCK_STREAM,
+        Listen => 1,
+    );
+    bless { sock => $sock }, $class;
+}
+
+1;


### PR DESCRIPTION
I added Test::UNIXSock module.
This is a port of Test::TCP for UNIX domain socket server testing.
