### PR TITLE
Avoid test failures if ip_nonlocal_bind is enabled

### DIFF
--- a/t/11_net_empty_port.t
+++ b/t/11_net_empty_port.t
@@ -23,7 +23,7 @@ sub doit {
 };
 
 ok can_bind('127.0.0.1'), 'bind to 127.0.0.1';
-ok ! can_bind('8.8.8.8'), 'bind to an anvailable address';
+ok ! can_bind('8.8.8.8'), 'bind to an unavailable address';
 
 subtest 'v4' => sub {
     doit('127.0.0.1');

--- a/t/11_net_empty_port.t
+++ b/t/11_net_empty_port.t
@@ -23,7 +23,19 @@ sub doit {
 };
 
 ok can_bind('127.0.0.1'), 'bind to 127.0.0.1';
-ok ! can_bind('8.8.8.8'), 'bind to an unavailable address';
+
+# Skip this check if binding to non-local addresses is enabled (most common
+# on load balancers with floating IPs)
+SKIP: {
+    if (-f '/proc/sys/net/ipv4/ip_nonlocal_bind') {
+        open my $fh, "<", "/proc/sys/net/ipv4/ip_nonlocal_bind";
+        if (<$fh> =~ /1/) {
+            skip "Binding to non-local adddresses is allowed";
+        } else {
+            ok ! can_bind('8.8.8.8'), 'bind to an unavailable address';
+        }
+    }
+}
 
 subtest 'v4' => sub {
     doit('127.0.0.1');

--- a/t/11_net_empty_port.t
+++ b/t/11_net_empty_port.t
@@ -8,9 +8,10 @@ sub doit {
     my $host = shift;
 
     my $port = empty_port();
-    ok "found an empty port";
+    ok $port, "found an empty port on $host";
 
-    ok !wait_port({ host => $host, port => $port, max_wait => 0.1 }), "port is closed";
+    ok !wait_port({ host => $host, port => $port, max_wait => 0.1 }),
+        "port $port on $host is closed";
 
     my $sock = IO::Socket::IP->new(
         LocalAddr => $host,
@@ -19,7 +20,8 @@ sub doit {
         V6Only    => 1,
     ) or die "Couldn't create socket: $!";
 
-    ok wait_port({ host => $host, port => $port, max_wait => 3 }), "port is open";
+    ok wait_port({ host => $host, port => $port, max_wait => 3 }),
+        "port $port on $host is now open";
 };
 
 ok can_bind('127.0.0.1'), 'bind to 127.0.0.1';
@@ -32,7 +34,7 @@ SKIP: {
         if (<$fh> =~ /1/) {
             skip "Binding to non-local adddresses is allowed";
         } else {
-            ok ! can_bind('8.8.8.8'), 'bind to an unavailable address';
+            ok ! can_bind('8.8.8.8'), 'Cannot bind to an unavailable address';
         }
     }
 }
@@ -44,7 +46,7 @@ subtest 'v4' => sub {
 subtest 'v6' => sub {
     plan skip_all => "IPv6 not supported"
         unless eval { Socket::IPV6_V6ONLY } and can_bind("::1");
-    ok "found an empty port";
+    diag "found an empty IPv6 port";
     doit('::1');
 };
 


### PR DESCRIPTION
Currently, a test fails if `/proc/sys/net/ipv4/ip_nonlocal_bind` is enabled.

This PR adds a check for that setting being present & enabled, and skips the test if so.