### PR TITLE
Ensure that IO::Socket::IP is DESTROY'd before can_bind returns

### DIFF
--- a/lib/Net/EmptyPort.pm
+++ b/lib/Net/EmptyPort.pm
@@ -10,7 +10,10 @@ our @EXPORT_OK = qw/ listen_socket /;
 
 sub can_bind {
     my ($host, $port, $proto) = @_;
-    defined _listen_socket($host, $port, $proto);
+    # The following must be split across two statements, due to
+    # https://rt.perl.org/Public/Bug/Display.html?id=124248
+    my $s = _listen_socket($host, $port, $proto);
+    return defined $s;
 }
 
 sub _listen_socket {

--- a/t/11_net_empty_port.t
+++ b/t/11_net_empty_port.t
@@ -36,4 +36,13 @@ subtest 'v6' => sub {
     doit('::1');
 };
 
+subtest 'return value' => sub {
+    my $sock = IO::Socket::IP->new(
+        LocalAddr => '127.0.0.1',
+        LocalPort => empty_port(),
+        Listen    => 1,
+    );
+    ok $sock;
+};
+
 done_testing;


### PR DESCRIPTION
be316f1f worked around a core perl bug[1] which causes Perl < 5.24.0
to DESTROY the IO::Socket::IP object too late, causing the empty port
to not actually be empty if it was used immediately.

Unfortunately, this change was lost in ba745fd1, which again put the
return of `can_bind` on the stack along with the actual return value,
re-instating the bug.

Split the statement across two statements again, and add a comment on
the importance of preserving it.

[1] https://rt.perl.org/Public/Bug/Display.html?id=124248

Fixes #50 