### PR TITLE
Revert "Fix issue #43 - Make MSWin32 use check_port in the same way other platforms do."

### DIFF
--- a/lib/Net/EmptyPort.pm
+++ b/lib/Net/EmptyPort.pm
@@ -124,7 +124,7 @@ sub wait_port {
     my $waiter = _make_waiter($max_wait);
 
     while ( $waiter->() ) {
-        if (check_port({ host => $host, port => $port, proto => $proto })) {
+        if ($^O eq 'MSWin32' ? `$^X -MTest::TCP::CheckPort -echeck_port $port $proto` : check_port({ host => $host, port => $port, proto => $proto })) {
             return 1;
         }
     }


### PR DESCRIPTION
Reverts tokuhirom/Test-TCP#53