### PR TITLE
Make Test::TCP::CheckPort able to pass hashref containing $host.

### DIFF
--- a/lib/Net/EmptyPort.pm
+++ b/lib/Net/EmptyPort.pm
@@ -124,7 +124,7 @@ sub wait_port {
     my $waiter = _make_waiter($max_wait);
 
     while ( $waiter->() ) {
-        if ($^O eq 'MSWin32' ? `$^X -MTest::TCP::CheckPort -echeck_port $port $proto` : check_port({ host => $host, port => $port, proto => $proto })) {
+        if ($^O eq 'MSWin32' ? `$^X -MTest::TCP::CheckPort -echeck_port $host $port $proto` : check_port({ host => $host, port => $port, proto => $proto })) {
             return 1;
         }
     }

--- a/lib/Test/TCP/CheckPort.pm
+++ b/lib/Test/TCP/CheckPort.pm
@@ -6,7 +6,13 @@ use Net::EmptyPort qw();
 
 our @EXPORT = qw/ check_port /;
 
-sub check_port { print Net::EmptyPort::check_port( @ARGV ) }
+sub check_port {
+    if ( @ARGV == 3) {
+        print Net::EmptyPort::check_port( { host => $ARGV[0], port => $ARGV[1], proto => $ARGV[2] } );
+    } else {
+        print Net::EmptyPort::check_port( @ARGV );
+    }
+}
 
 1;
 


### PR DESCRIPTION
As discussed in #53, issue #43 is caused because _wait_port_/_check_port_ logic does not consider IPv6-enabled Windows hosts. This pull request attempts to fix this by modifying Test::TCP::CheckPort and its caller to pass `host` as well as `port` and `proto`.

An attempt at backwards compatibility has been made in that Test::TCP::CheckPort will still behave in the same way if passed only two arguments.

All tests pass on Win7 & Win10 with these changes.