### PR TITLE
Don't run author tests for testing Modules

### DIFF
--- a/xt/04_dependents.t
+++ b/xt/04_dependents.t
@@ -13,10 +13,12 @@ use File::Temp qw(tempdir);
 plan skip_all => "No cpanm" unless which('cpanm');
 
 local $ENV{PERL_CPANM_OPT} = '--no-man-pages --no-prompt --no-interactive';
+local $ENV{RELEASE_TESTING};
+local $ENV{AUTHOR_TESTING};
 
 my $tmp = tempdir(CLEANUP => 1);
 is(system("cpanm --notest -l $tmp ."), 0);
-for (qw(Monoceros Plack POSIX::getpeername Starman Dancer2)) {
+for (qw(Plack POSIX::getpeername Starman Dancer2)) {
     is(system("cpanm -l $tmp --reinstall $_"), 0, $_);
 }
 


### PR DESCRIPTION
And remove Monoceros because its test is broken. Some author's tests are failed by missing some modules(they are not installed by cpanm by default).