### PR TITLE
don't run command when the port is empty

### DIFF
--- a/lib/Net/EmptyPort.pm
+++ b/lib/Net/EmptyPort.pm
@@ -131,7 +131,7 @@ sub wait_port {
     my $waiter = _make_waiter($max_wait);
 
     while ( $waiter->() ) {
-        if ($^O eq 'MSWin32' ? `$^X -MTest::TCP::CheckPort -echeck_port $host $port $proto` : check_port({ host => $host, port => $port, proto => $proto })) {
+        if ($^O eq 'MSWin32' && defined($port) ? `$^X -MTest::TCP::CheckPort -echeck_port $host $port $proto` : check_port({ host => $host, port => $port, proto => $proto })) {
             return 1;
         }
     }


### PR DESCRIPTION
Test::TCP do hack on Windows for checking port used.

https://github.com/tokuhirom/Test-TCP/commit/0f4510d8

But this way always return 0 with succeeded with empty port. This is not
expected behavior. So this change fix to call check_port if the port is
not defined.

fixes #60