### PR TITLE
Don't upgrade Test::Simple in Windows CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -43,7 +43,6 @@ install:
   - set PERL_MM_USE_DEFAULT=1
   - set NONINTERACTIVE_TESTING=1
   - set PERL_MM_NONINTERACTIVE=1
-  - cpanm Test::Simple
   - cpanp o >outdated.txt
   - type outdated.txt
 build_script:


### PR DESCRIPTION
All tests pass on Windows in current HEAD, see https://ci.appveyor.com/project/nponeccop/test-tcp/build/1.0.14 so the `cpanm install Test::Simple` line is unnecessary