### PR TITLE
Fix tests for '.' in @INC - attempt 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: perl
-before_install:
-  - cpanm inc::Module::Install Module::Install::AuthorTests
 perl:
+  - "5.26"
   - "5.14"

--- a/t/01_simple.t
+++ b/t/01_simple.t
@@ -4,7 +4,7 @@ use Test::More;
 use Test::TCP;
 use Net::EmptyPort qw(can_bind);
 use IO::Socket::IP;
-use t::Server;
+BEGIN { require './t/Server.pm' }
 
 sub doit {
     my $host = shift;

--- a/t/02_abrt.t
+++ b/t/02_abrt.t
@@ -4,7 +4,7 @@ use Test::TCP;
 use Test::More;
 use Socket;
 use IO::Socket::INET;
-use t::Server;
+BEGIN { require './t/Server.pm' }
 
 plan skip_all => "win32 doesn't support embedded function named dump()" if $^O eq 'MSWin32';
 plan tests => 2;

--- a/t/03_return_when_sigterm.t
+++ b/t/03_return_when_sigterm.t
@@ -2,7 +2,10 @@ use warnings;
 use strict;
 use Test::More tests => 2;
 use Test::TCP;
-use t::Server;
+BEGIN {
+  require './t/Server.pm';
+  t::Server->import();
+}
 
 # ABOUT: some tcp server related software returns control when received SIGTERM instead of exit.
 # This test emulate it's situation.

--- a/t/04_die.t
+++ b/t/04_die.t
@@ -3,7 +3,7 @@ use strict;
 use Test::More tests => 9;
 use Test::TCP;
 use IO::Socket::INET;
-use t::Server;
+BEGIN { require './t/Server.pm' }
 
 my $child_pid;
 eval {

--- a/t/06_nest.t
+++ b/t/06_nest.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use Test::TCP;
 use Test::More tests => 1;
-use t::Server;
+BEGIN { require './t/Server.pm' }
 
 test_tcp(
     client => sub {

--- a/t/08_exit.t
+++ b/t/08_exit.t
@@ -4,7 +4,7 @@ use Test::More tests => 5;
 use Test::TCP;
 use File::Temp ();
 use Fcntl qw/:seek/;
-use t::Server;
+BEGIN { require './t/Server.pm' }
 use POSIX;
 
 my $tmp = File::Temp->new();

--- a/t/09_fork.t
+++ b/t/09_fork.t
@@ -1,7 +1,7 @@
 use strict;
 use Test::More tests => 6;
 use Test::TCP;
-use t::Server;
+BEGIN { require './t/Server.pm' }
 
 test_tcp 
     client => sub {

--- a/t/10_oo.t
+++ b/t/10_oo.t
@@ -3,7 +3,7 @@ use strict;
 use Test::More tests => 24;
 use Test::TCP;
 use IO::Socket::INET;
-use t::Server;
+BEGIN { require './t/Server.pm' }
 
 my $server = Test::TCP->new(
     code => sub {

--- a/t/12_pass_wait_port_options.t
+++ b/t/12_pass_wait_port_options.t
@@ -4,7 +4,7 @@ use utf8;
 use Test::More;
 use Test::TCP;
 use IO::Socket::INET;
-use t::Server;
+BEGIN { require './t/Server.pm' }
 
 my %wait_port_args;
 my $old = \&Net::EmptyPort::wait_port;

--- a/t/13_undef_port.t
+++ b/t/13_undef_port.t
@@ -3,7 +3,7 @@ use strict;
 use Test::More tests => 22;
 use Test::TCP;
 use IO::Socket::INET;
-use t::Server;
+BEGIN { require './t/Server.pm' }
 
 test_tcp(
     client => sub {


### PR DESCRIPTION
Apparently #58 failed because of some heisenbug in Travis itself.

I basically added a commit to remove extra dependencies which are needed with Module::Install-based distros but aren't needed with Minilla-based distros. And added 5.26 build, so now we build both 5.14 and 5.26
