### PR TITLE
cosmetic fixes for minil dist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ inc/
 pm_to_blib
 *.sw[po]
 ^\.git/
+MANIFEST
 MANIFEST.bak
 *.old
 MYMETA.*

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,3 @@
+Tokuhiro Matsuno <tokuhirom@gmail.com> tokuhirom <tokuhirom@d0d07461-0603-4401-acd4-de1884942a52>
+Tokuhiro Matsuno <tokuhirom@gmail.com> tokuhirom <tokuhirom@gmail.com>
+Tatsuhiko Miyagawa <miyagawa@gmail.com> Tatsuhiko Miyagawa <miyagawa@bulknews.net>

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -1,0 +1,6 @@
+.appveyor.yml
+.travis.yml
+cpanfile
+minil.toml
+.git
+.build

--- a/lib/Test/TCP.pm
+++ b/lib/Test/TCP.pm
@@ -155,7 +155,7 @@ sub DESTROY {
 1;
 __END__
 
-=for stopwords OO
+=for stopwords OO loopback
 
 =encoding utf8
 

--- a/xt/02_perlcritic.t
+++ b/xt/02_perlcritic.t
@@ -15,7 +15,7 @@ eval {
 note $@ if $@;
 plan skip_all => "Perl::Critic 1.105+ or Test::Perl::Critic 1.02+ is not installed." if $@;
 
-all_critic_ok('lib', 'script', 'bin');
+all_critic_ok('lib');
 
 __END__
 


### PR DESCRIPTION
- put `MANIFEST` to `.gitignore`
- add committer aliases to `.mailmap` to avoid duplicate contributors in `META.json`
- add `MANIFEST.SKIP` so CI configs are not packaged and `make distcheck` passes
- add a `Test::Spellunker` stopword so Minilla spell checking passes
- remove non-existent dirs from `Perl::Critic` search paths so it doesn't display warnings