### PR TITLE
Fix race condition in check_port(UDP)

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Perl module Test::TCP
 
 {{$NEXT}}
+    - Fix race condition in check_port(UDP) #78
 
 2.20 2019-08-03T22:47:58Z
 

--- a/lib/Net/EmptyPort.pm
+++ b/lib/Net/EmptyPort.pm
@@ -2,6 +2,8 @@ package Net::EmptyPort;
 use strict;
 use warnings;
 use base qw/Exporter/;
+use Errno qw/ECONNREFUSED/;
+use Fcntl;
 use IO::Socket::IP;
 use Time::HiRes ();
 
@@ -68,25 +70,17 @@ sub check_port {
     my ($host, $port, $proto) = @_ && ref $_[0] eq 'HASH' ? ($_[0]->{host}, $_[0]->{port}, $_[0]->{proto}) : (undef, @_);
     $host = '127.0.0.1'
         unless defined $host;
-    $proto = $proto ? lc($proto) : 'tcp';
 
-    # for TCP, we do a remote port check
-    # for UDP, we do a local port check, like empty_port does
-    my $sock = ($proto eq 'tcp') ?
-        IO::Socket::IP->new(
-            Proto    => 'tcp',
-            PeerAddr => $host,
-            PeerPort => $port,
-            V6Only   => 1,
-        ) :
-        IO::Socket::IP->new(
-            Proto     => $proto,
-            LocalAddr => $host,
-            LocalPort => $port,
-            V6Only   => 1,
-            (($^O eq 'MSWin32') ? () : (ReuseAddr => 1)),
-        )
-    ;
+    return _check_port_udp($host, $port)
+        if $proto && lc($proto) eq 'udp';
+
+    # TCP, check if possible to connect
+    my $sock = IO::Socket::IP->new(
+        Proto    => 'tcp',
+        PeerAddr => $host,
+        PeerPort => $port,
+        V6Only   => 1,
+    );
 
     if ($sock) {
         close $sock;
@@ -97,6 +91,34 @@ sub check_port {
     }
 
 }
+
+sub _check_port_udp {
+    my ($host, $port) = @_;
+
+    # send some UDP data and see if ICMP error is being sent back (i.e. ECONNREFUSED)
+    my $sock = IO::Socket::IP->new(
+        Proto    => 'udp',
+        PeerAddr => $host,
+        PeerPort => $port,
+        V6Only   => 1,
+    ) or die "failed to create bound UDP socket:$!";
+    fcntl($sock, F_SETFL, O_NONBLOCK)
+      or die "failed to set socket to nonblocking mode:$!";
+
+    $sock->send("0", 0)
+        or die "failed to send a UDP packet:$!";
+
+    my ($rfds, $efds) = ('', '');
+    vec($rfds, fileno($sock), 1) = 1;
+    vec($efds, fileno($sock), 1) = 1;
+    select $rfds, undef, $efds, 0.1;
+
+    # after 0.1 second of silence, we assume that the server is up
+    my $up = defined($sock->recv(my $data, 1000)) || $! != ECONNREFUSED;
+    close $sock;
+    $up;
+}
+
 
 sub _make_waiter {
     my $max_wait = shift;

--- a/lib/Net/EmptyPort.pm
+++ b/lib/Net/EmptyPort.pm
@@ -268,6 +268,8 @@ Checks if the given port is already in use. Returns true if it is in use (i.e. i
 
 The function recognizes the following keys when given a hashref as the argument.
 
+When UDP is specified as the protocol, the `check_port` function sends a probe UDP packet to the designated port to see if an ICMP error message is returned, which indicates that the port is unassigned.  The port is assumed to be assigned, unless such response is observed within 0.1 seconds.
+
 =over 4
 
 =item C<< host >>

--- a/t/11_net_empty_port.t
+++ b/t/11_net_empty_port.t
@@ -83,4 +83,15 @@ eval { check_port (); };
 like ($@, qr/Expected .PeerService./, 'No args to check_port is fatal');
 ok (!check_port (empty_port(), 'tcp'), '2 args to check_port');
 
+subtest 'udp-wait-port' => sub {
+    my $port = empty_port({proto => 'udp'});
+    ok !check_port($port, 'udp'), "port is down";
+    my $sock = IO::Socket::IP->new(
+        Proto     => 'udp',
+        LocalPort => $port,
+        V6Only    => 1,
+    ) or die "failed to bind to a UDP socket:$!";
+    ok check_port($port, 'udp'), "port is up";
+};
+
 done_testing;


### PR DESCRIPTION
At the moment, the check_port function checks if a UDP port is being used by actually trying to bind to that port. This approach is racy.

This PR introduces a safer approach, where we send a UDP probe packet and see if an ICMP error is being delivered in response within 0.1 seconds. If not, we assume that the server is up.

I've also added a test case covering the use of check_port(UDP) which did not exist.