### PR TITLE
Portability fixes for Win32 perl older than 5.24

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -51,4 +51,6 @@ build_script:
 # chcp without parameter, we can see that locale is 437 instead of 65001 which means
 # some version of 8-bit European charset instead of UTF-8 required by some modules of
 # Japanese origin
+  - chcp 65001 && cpanm --installdeps --notest --quiet .
+  - chcp 65001 && prove -v -I./lib t/01_simple.t
   - chcp 65001 && cpanm --test-only -v .

--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Perl module Test::TCP
 
 {{$NEXT}}
+    - Portability fixes for Win32 perl older than 5.24 #88
 
 2.22 2019-10-08T08:15:34Z
     - Portability fixes for Win32 and non-linux #83, #87

--- a/t/01_simple.t
+++ b/t/01_simple.t
@@ -46,6 +46,9 @@ sub doit {
     );
 }
 
+ok 1, "starting the tests";
+
+
 subtest 'v4' => sub {
     doit('127.0.0.1');
 };


### PR DESCRIPTION
The new `WSA*` constants are only supported since Perl 5.24 according
to `man perlport`.. So on older perls such as 5.20.3
the 11_empty_port.t test failed with "Undefined subroutine
&Errno::WSAECONNRESET" error.

Closes #88